### PR TITLE
added GitHub CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,11 +24,13 @@ jobs:
     - name: conda env setup
       shell: bash -l {0}
       run: |
-        conda install -y r-base=${{ matrix.r-version }} r-renv
+        conda install -y mamba
+        mamba install -y r-base=${{ matrix.r-version }} r-renv r-nloptr r-data.table r-dplyr r-ggplot2 r-ggraph r-igraph r-stringr
     - uses: actions/checkout@v2	
     - name: renv install
       shell: bash -l {0}
       run: |
+        R -e 'renv::install("rstudio/renv")'
         R -e 'renv::install("nick-youngblut/endoR")'
     - name: Package unit tests
       shell: bash -l {0}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,36 @@
+name: EndoR
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+    name: build (${{ matrix.r-version }}, ${{ matrix.os }})
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        r-version: [4.0.3]
+    steps:
+    - uses: conda-incubator/setup-miniconda@v2
+      with:
+        miniconda-version: 'latest'
+        auto-update-conda: true
+        python-version: 3.8
+        channels: conda-forge,bioconda
+        activate-environment: endor_env
+    - name: conda env setup
+      shell: bash -l {0}
+      run: |
+        conda install -y r-base=${{ matrix.r-version }} r-renv
+    - uses: actions/checkout@v2	
+    - name: renv install
+      shell: bash -l {0}
+      run: |
+        renv::install("aruaud/endoR")
+    - name: Package unit tests
+      shell: bash -l {0}
+      run: |
+        echo "currently, none"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: EndoR
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
 
 jobs:
   build:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
       shell: bash -l {0}
       run: |
         conda install -y mamba
-        mamba install -y r-base=${{ matrix.r-version }} r-renv r-nloptr r-data.table r-dplyr r-ggplot2 r-ggraph r-igraph r-stringr
+        mamba install -y r-base=${{ matrix.r-version }} r-renv r-nloptr
     - uses: actions/checkout@v2	
     - name: renv install
       shell: bash -l {0}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,12 +24,12 @@ jobs:
     - name: conda env setup
       shell: bash -l {0}
       run: |
-        conda install -y r-base=${{ matrix.r-version }} r-renv
+        conda install -y r-base=${{ matrix.r-version }} conda-forge::r-devtools
     - uses: actions/checkout@v2	
     - name: renv install
       shell: bash -l {0}
       run: |
-        R -e 'renv::install("aruaud/endoR")'
+        R -e 'devtools::install_github(repo = "aruaud/endoR")'
     - name: Package unit tests
       shell: bash -l {0}
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
     - name: renv install
       shell: bash -l {0}
       run: |
-        R -e 'devtools::install_github(repo = "aruaud/endoR")'
+        R -e 'devtools::install_github(repo = "nick-youngblut/endoR")'
     - name: Package unit tests
       shell: bash -l {0}
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
     - name: renv install
       shell: bash -l {0}
       run: |
-        renv::install("aruaud/endoR")
+        R -e 'renv::install("aruaud/endoR")'
     - name: Package unit tests
       shell: bash -l {0}
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       with:
         miniconda-version: 'latest'
         auto-update-conda: true
-        python-version: 3.8
+        python-version: 3.10
         channels: conda-forge,bioconda,defaults
         activate-environment: endor_env
     - name: conda env setup

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,12 +24,12 @@ jobs:
     - name: conda env setup
       shell: bash -l {0}
       run: |
-        conda install -y r-base=${{ matrix.r-version }} conda-forge::r-devtools
+        conda install -y r-base=${{ matrix.r-version }} r-renv
     - uses: actions/checkout@v2	
     - name: renv install
       shell: bash -l {0}
       run: |
-        R -e 'devtools::install_github(repo = "nick-youngblut/endoR")'
+        R -e 'renv::install("nick-youngblut/endoR")'
     - name: Package unit tests
       shell: bash -l {0}
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        r-version: [4.0.3]
+        r-version: [4.1]
     steps:
     - uses: conda-incubator/setup-miniconda@v2
       with:
@@ -25,7 +25,7 @@ jobs:
       shell: bash -l {0}
       run: |
         conda install -y mamba
-        mamba install -y r-base=${{ matrix.r-version }} r-renv r-nloptr
+        mamba install -y r-base=${{ matrix.r-version }} r-renv r-nloptr r-data.table r-dplyr r-ggplot2 r-ggraph r-igraph r-stringr
     - uses: actions/checkout@v2	
     - name: renv install
       shell: bash -l {0}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
         miniconda-version: 'latest'
         auto-update-conda: true
         python-version: 3.8
-        channels: conda-forge,bioconda
+        channels: conda-forge,bioconda,defaults
         activate-environment: endor_env
     - name: conda env setup
       shell: bash -l {0}
@@ -31,8 +31,9 @@ jobs:
       shell: bash -l {0}
       run: |
         R -e 'renv::install("rstudio/renv")'
+        R -e 'renv::install("softwaredeng/inTrees/inTrees.Rcheck/inTrees")'
         R -e 'renv::install("nick-youngblut/endoR")'
     - name: Package unit tests
       shell: bash -l {0}
       run: |
-        echo "currently, none"
+        R -e 'library(endoR)'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       with:
         miniconda-version: 'latest'
         auto-update-conda: true
-        python-version: 3.10
+        python-version: '3.10'
         channels: conda-forge,bioconda,defaults
         activate-environment: endor_env
     - name: conda env setup


### PR DESCRIPTION
It took a few tries, but I found a method of successfully installing endoR.

Note: you should change `R -e 'renv::install("nick-youngblut/endoR")'` to R -e 'renv::install("aruaud/endoR")'

You can easily add multiple R versions via `r-version: [4.1]` and unit tests via:

```
    - name: Package unit tests
      shell: bash -l {0}
      run: |
        R -e 'library(endoR)'
```